### PR TITLE
Changes typhoeus for HTTParty

### DIFF
--- a/khipu-api-client.gemspec
+++ b/khipu-api-client.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'httparty', '0.20.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
-  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/khipu-api-client.gemspec
+++ b/khipu-api-client.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |s|
   s.description = %q{This gem maps to a swagger API}
   s.license     = "Apache-2.0"
 
-  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'httparty', '0.20.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'

--- a/lib/khipu-api-client/api_client.rb
+++ b/lib/khipu-api-client/api_client.rb
@@ -32,8 +32,7 @@ module Khipu
     end
 
     def call_api(http_method, path, opts = {})
-      request = build_request(http_method, path, opts)
-      response = request.run
+      response = build_request(http_method, path, opts)
 
       # record as last response
       @last_response = response

--- a/lib/khipu-api-client/api_client.rb
+++ b/lib/khipu-api-client/api_client.rb
@@ -2,11 +2,11 @@ require 'date'
 require 'json'
 require 'logger'
 require 'tempfile'
-require 'typhoeus'
 require 'uri'
 require 'net/http'
 require 'openssl'
 require 'base64'
+require 'httparty'
 
 module Khipu
   class ApiClient
@@ -64,9 +64,7 @@ module Khipu
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
-      
       update_params_for_auth! @host, path, http_method, header_params, query_params, form_params, opts[:auth_names], opts[:body]
-      
 
       req_opts = {
         :method => http_method,
@@ -87,7 +85,7 @@ module Khipu
         end
       end
 
-      Typhoeus::Request.new(url, req_opts)
+      HTTParty.send(req_opts[:method], url, { headers: req_opts[:headers], body: req_opts[:body] })
     end
 
     # Deserialize the response to the given return type.

--- a/lib/khipu-api-client/configuration.rb
+++ b/lib/khipu-api-client/configuration.rb
@@ -77,8 +77,6 @@ module Khipu
     #
     # @return [String] the path to the certificate file
     #
-    # @see The `cainfo` option of Typhoeus, `--cert` option of libcurl. Related source code:
-    # https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L145
     attr_accessor :ssl_ca_cert
 
     # Client certificate file (for client certificate)


### PR DESCRIPTION
typhoeus causes problems when using in lamba as it depends on libcurl. it is true you can use a lambda layer to handle this dependency, its use is more complex than it should, and it still having some problems that are harder to address than simple using HTTParty, which does not depends on libcurl, and it is straightforward to implement.